### PR TITLE
Enforce function return types with `eslint`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
 	plugins: ['react', 'import', 'simple-import-sort', 'sort-keys-fix'],
 	root: true,
 	rules: {
+		'@typescript-eslint/explicit-function-return-type': 'error',
 		'import/first': 'error',
 		'import/newline-after-import': 'error',
 		'import/no-default-export': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "laszloborbely.com",
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "laszloborbely.com",
-			"version": "2.4.2",
+			"version": "2.4.3",
 			"dependencies": {
 				"@tanstack/react-query": "5.18.1",
 				"axios": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "laszloborbely.com",
 	"private": true,
-	"version": "2.4.2",
+	"version": "2.4.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,9 +1,10 @@
 import { ReactElement, type ReactNode } from 'react';
 
-export function Container(props: {
+interface ContainerProps {
 	children?: ReactElement | ReactNode | string;
-}) {
-	const { children } = props;
+}
+
+export function Container({ children }: ContainerProps): ReactElement {
 	return (
 		<div className='d-flex flex-column align-items-center h-100 col-11 col-lg-12 m-auto flex-grow-1'>
 			{children}

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -1,9 +1,10 @@
 import { ReactElement, type ReactNode } from 'react';
 
-export function Content(props: {
+interface ContentProps {
 	children?: ReactElement | ReactNode | string;
-}) {
-	const { children } = props;
+}
+
+export function Content({ children }: ContentProps): ReactElement {
 	const classes = [
 		'd-flex',
 		'flex-column',

--- a/src/components/ContentRow/index.tsx
+++ b/src/components/ContentRow/index.tsx
@@ -1,7 +1,14 @@
-import { type ReactNode } from 'react';
+import { ReactElement, type ReactNode } from 'react';
 
-export function ContentRow(props: { center?: boolean; children?: ReactNode }) {
-	const { children, center } = props;
+interface ContentRowProps {
+	center?: boolean;
+	children?: ReactNode;
+}
+
+export function ContentRow({
+	children,
+	center,
+}: ContentRowProps): ReactElement {
 	const centerClasses = [
 		'd-flex',
 		'flex-row',

--- a/src/components/Frame/index.tsx
+++ b/src/components/Frame/index.tsx
@@ -1,11 +1,14 @@
 import './index.css';
 
-import { type ReactNode } from 'react';
+import { ReactElement, type ReactNode } from 'react';
 
 import { Navbar } from '../Navbar';
 
-export function Frame(props: { children?: ReactNode }) {
-	const { children } = props;
+interface FrameProps {
+	children?: ReactNode;
+}
+
+export function Frame({ children }: FrameProps): ReactElement {
 	const classes = [
 		'frame-container',
 		'm-0',

--- a/src/components/Links/index.tsx
+++ b/src/components/Links/index.tsx
@@ -1,9 +1,9 @@
-import { Fragment } from 'react';
+import { Fragment, ReactElement } from 'react';
 
 import { type RouteProps, routes } from '../../routes';
 import { PureLinkHighlight } from '../PureLinkHighlight';
 
-export function Links() {
+export function Links(): ReactElement {
 	const elements = routes
 		.sort((a, b) => Number(b.id) - Number(a.id))
 		.filter((route: RouteProps) => route.display)

--- a/src/components/MarkdownRenderer/index.tsx
+++ b/src/components/MarkdownRenderer/index.tsx
@@ -1,11 +1,18 @@
 import './index.css';
 
+import { ReactElement } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus as style } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import remarkGfm from 'remark-gfm';
 
-export function MarkdownRenderer({ content }: { content: string }) {
+interface MarkdownRendererProps {
+	content: string;
+}
+
+export function MarkdownRenderer({
+	content,
+}: MarkdownRendererProps): ReactElement {
 	return (
 		<ReactMarkdown
 			className='markdown-body'

--- a/src/components/Navbar/index.spec.tsx
+++ b/src/components/Navbar/index.spec.tsx
@@ -1,11 +1,12 @@
 import { cleanup, render } from '@testing-library/react';
+import { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Navbar } from './';
 
 const mocked = vi.hoisted(() => ({
-	component: () => <div />,
+	component: (): ReactElement => <div />,
 }));
 
 vi.mock('../Links', () => ({

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,14 +1,13 @@
 import './index.css';
 
-import { type ReactNode } from 'react';
+import { ReactElement, type ReactNode } from 'react';
 
-// Assets
 import logo from '../../assets/images/logo.svg';
 import { Links } from '../Links';
 import { PureLinkHighlight } from '../PureLinkHighlight';
 import { Separator } from '../Separator';
 
-export function Navbar() {
+export function Navbar(): ReactElement {
 	return (
 		<CommonNavbar>
 			<div className='d-flex flex-row-reverse align-items-center gap-3'>
@@ -18,9 +17,11 @@ export function Navbar() {
 	);
 }
 
-function CommonNavbar(props: { children?: ReactNode }) {
-	const { children } = props;
+interface CommonNavbarProps {
+	children?: ReactNode;
+}
 
+function CommonNavbar({ children }: CommonNavbarProps): ReactElement {
 	return (
 		<div className='col-11 col-lg-12 m-auto'>
 			<div className='w-100 d-flex justify-content-between align-items-center mb-2'>

--- a/src/components/PostMetadata/index.tsx
+++ b/src/components/PostMetadata/index.tsx
@@ -1,10 +1,15 @@
 import './index.css';
 
 import moment from 'moment/moment';
+import { ReactElement } from 'react';
 
 import { type BlogPostData } from '../../network/types/blog';
 
-export function PostMetadata({ post }: { post: BlogPostData }) {
+interface PostMetadataProps {
+	post: BlogPostData;
+}
+
+export function PostMetadata({ post }: PostMetadataProps): ReactElement {
 	const dateFormat = 'LL';
 	const timestamp = moment(post.creationTime).format(dateFormat);
 	return (

--- a/src/components/PureLinkHighlight/index.tsx
+++ b/src/components/PureLinkHighlight/index.tsx
@@ -1,8 +1,15 @@
-import { type ReactNode } from 'react';
+import { ReactElement, type ReactNode } from 'react';
 import { NavLink } from 'react-router-dom';
 
-export function PureLinkHighlight(props: { to: string; children?: ReactNode }) {
-	const { to, children } = props;
+interface PureLinkHighlightProps {
+	to: string;
+	children?: ReactNode;
+}
+
+export function PureLinkHighlight({
+	to,
+	children,
+}: PureLinkHighlightProps): ReactElement {
 	return (
 		<NavLink
 			to={to}

--- a/src/components/Separator/index.tsx
+++ b/src/components/Separator/index.tsx
@@ -1,5 +1,7 @@
 import './index.css';
 
-export function Separator() {
+import { ReactElement } from 'react';
+
+export function Separator(): ReactElement {
 	return <div className='separator w-100 mb-3' />;
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,9 +1,10 @@
+import { ReactElement } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import { routes } from './routes';
 
-export function Router() {
+export function Router(): ReactElement {
 	const router = createBrowserRouter(routes);
 
 	return (

--- a/src/routes/Blog.tsx
+++ b/src/routes/Blog.tsx
@@ -12,7 +12,7 @@ import { Spinner } from '../components/Spinner';
 import { postsQueryOptions } from '../network/queryOptions';
 import { getPageTitle } from '../utils/title';
 
-export function Blog() {
+export function Blog(): ReactElement {
 	return (
 		<Frame>
 			<Container>

--- a/src/routes/Contact.tsx
+++ b/src/routes/Contact.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import { Container } from '../components/Container';
@@ -6,7 +7,7 @@ import { ContentRow } from '../components/ContentRow';
 import { Frame } from '../components/Frame';
 import { pageTitleSuffix } from '../config';
 
-export function Contact() {
+export function Contact(): ReactElement {
 	const name = 'Contact';
 	const pageTitle = [name, pageTitleSuffix].join(' | ');
 

--- a/src/routes/NotFound.tsx
+++ b/src/routes/NotFound.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import { Container } from '../components/Container';
@@ -6,7 +7,7 @@ import { ContentRow } from '../components/ContentRow';
 import { Frame } from '../components/Frame';
 import { pageTitleSuffix } from '../config';
 
-export function NotFound() {
+export function NotFound(): ReactElement {
 	const name = '404';
 	const pageTitle = [name, pageTitleSuffix].join(' | ');
 	return (


### PR DESCRIPTION
Activated the `@typescript-eslint/explicit-function-return-type` rule to make sure no function remains untyped.