### PR TITLE
Fix Markdown syntax highlighting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,8 +57,4 @@ const manualChunksOptions: ManualChunksOption = (id: string) => {
 	if (id.includes('moment')) {
 		return 'moment';
 	}
-
-	if (id.includes('refractor')) {
-		return 'refractor';
-	}
 };


### PR DESCRIPTION
As a result of some manual build optimisation, the `refractor` styles no longer applied to code blocks. By removing the package from the manual build chunk configuration, the syntax highlighting should work again.